### PR TITLE
remove hidden dependency on ActiveSupport

### DIFF
--- a/lib/trailblazer/cell.rb
+++ b/lib/trailblazer/cell.rb
@@ -28,7 +28,7 @@ module Trailblazer
     # TODO: this should be in Helper or something. this should be the only entry point from controller/view.
     class << self
       def class_from_cell_name(name)
-        name.camelize.constantize
+        util.constant_for(util.camelize(name))
       end
 
       # Comment::Cell::Show #=> comment/view/


### PR DESCRIPTION
As it stands, trailblazer-cells has a dependency on ActiveSupport (even though
it's not specified in the gemspec), because `class_for_cell_name` expects
strings to have the methods `camelize` and `constantize` defined, which of
course are ActiveSupport monkey-patches and not part of Ruby core.

This PR removes this hidden dependency on ActiveSupport. However, `Cell::Util`
doesn't have a `camelize` method, so I added one [a PR on `cells`](https://github.com/trailblazer/cells/pull/447) and
the PR here won't work unless the PR on `cells` is also merged.

This also means that the dependency on `cells` from `trailblazer-cells` will
have to be updated to make sure that the new `camelize` method is available,
but I'll wait to see whether you want to accept this change in the first place
before worrying about dependencies