### PR TITLE
  add support for both "view" and "views" prefixes

### DIFF
--- a/lib/trailblazer/cell.rb
+++ b/lib/trailblazer/cell.rb
@@ -29,9 +29,7 @@ module Trailblazer
     class << self
 
       def _local_prefixes
-        view_paths.collect do |path|
-          view_dirs.collect { |dir| "#{path}/#{controller_path}/#{dir}" }
-        end.flatten
+        view_paths.product(view_dirs).collect { |path, dir| "#{path}/#{controller_path}/#{dir}" }
       end
 
       def view_dirs

--- a/lib/trailblazer/cell.rb
+++ b/lib/trailblazer/cell.rb
@@ -27,17 +27,24 @@ module Trailblazer
 
     # TODO: this should be in Helper or something. this should be the only entry point from controller/view.
     class << self
+
+      def _local_prefixes
+        view_paths.collect do |path|
+          view_dirs.collect { |dir| "#{path}/#{controller_path}/#{dir}" }
+        end.flatten
+      end
+
+      def view_dirs
+        %w(view views)
+      end
+
       def class_from_cell_name(name)
         name.camelize.constantize
       end
 
       # Comment::Cell::Show #=> comment/view/
       def controller_path
-        @controller_path ||= File.join(util.underscore(name.sub(/(::Cell.+)/, '')), views_dir)
-      end
-
-      def views_dir
-        "view"
+        @controller_path ||= File.join(util.underscore(name.sub(/(::Cell.+)/, '')))
       end
 
       def view_name

--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -52,14 +52,14 @@ end
 
 class CellTest < Minitest::Test
   describe "#prefixes" do
-    it { Post::Cell::New.prefixes.must_equal ["app/concepts/post/view"] }
-    it { Post::Cell::Show.prefixes.must_equal ["app/concepts/post/view"] }
-    it { Post::Cell::Show::SideBar.prefixes.must_equal ["test/concepts/post/view"] }
-    it { Post::Cell::Show::FlatSideBar.prefixes.must_equal ["test/concepts/post/view"] }
+    it { Post::Cell::New.prefixes.must_equal ["app/concepts/post/view", "app/concepts/post/views"] }
+    it { Post::Cell::Show.prefixes.must_equal ["app/concepts/post/view", "app/concepts/post/views"] }
+    it { Post::Cell::Show::SideBar.prefixes.must_equal ["test/concepts/post/view", "test/concepts/post/views"] }
+    it { Post::Cell::Show::FlatSideBar.prefixes.must_equal ["test/concepts/post/view", "test/concepts/post/views"] }
 
-    it { Admin::Post::Cell::New.prefixes.must_equal ["app/concepts/admin/post/view"] }
-    it { Admin::Post::Cell::Show.prefixes.must_equal ["app/concepts/admin/post/view"] }
-    it { Admin::Post::Cell::Show::SideBar.prefixes.must_equal ["app/concepts/admin/post/view"] }
+    it { Admin::Post::Cell::New.prefixes.must_equal ["app/concepts/admin/post/view", "app/concepts/admin/post/views"] }
+    it { Admin::Post::Cell::Show.prefixes.must_equal ["app/concepts/admin/post/view", "app/concepts/admin/post/views"] }
+    it { Admin::Post::Cell::Show::SideBar.prefixes.must_equal ["app/concepts/admin/post/view", "app/concepts/admin/post/views"] }
   end
 
   describe "::view_name" do


### PR DESCRIPTION
Issue: plural view folders, e.g. "app/concepts/post/views" would result in Cell::TemplateMissingError

Fix: added "views" to local prefixes. Now both file structures can work.