### PR TITLE
Use cell's name instead of `controller_path` in cache key generation

### DIFF
--- a/lib/trailblazer/cell.rb
+++ b/lib/trailblazer/cell.rb
@@ -44,6 +44,11 @@ module Trailblazer
         @view_name ||= _view_name
       end
 
+      # Computes the complete, namespaced cache key for +state+.
+      def state_cache_key(state, key_parts={})
+        expand_cache_key([util.underscore(name), state, key_parts])
+      end
+
       include ViewName::Path
     end
 

--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -1,6 +1,19 @@
 require "test_helper"
 require "cells-erb"
 
+module CacheStore
+  STORE = Class.new(Hash) do
+    def fetch(key, *)
+      value = self[key] || self[key] = yield
+      value
+    end
+  end.new
+
+  def cache_store
+    STORE
+  end
+end
+
 module Post
   module Cell
     class New < Trailblazer::Cell
@@ -10,12 +23,18 @@ module Post
       class SideBar < Trailblazer::Cell
         self.view_paths = ["test/concepts"]
         include ::Cell::Erb
+
+        include CacheStore
+        cache :show, expires_in: 10
       end
 
       class FlatSideBar < Trailblazer::Cell
         self.view_paths = ["test/concepts"]
         include ::Cell::Erb
         extend ViewName::Flat
+
+        include CacheStore
+        cache :show
       end
     end
   end
@@ -77,5 +96,24 @@ class CellTest < Minitest::Test
 
   describe "flat layout" do
     it { Post::Cell::Show::FlatSideBar.new(nil, layout: Post::Cell::Layout).().must_equal "layout{$flat_side_bar\n}\n" }
+  end
+
+  describe "::state_cache_key" do
+    it { Post::Cell::Show::SideBar.state_cache_key(:show, expiry: 1).must_equal "post/cell/show/side_bar/show/{:expiry=>1}" }
+    it { Post::Cell::Show::FlatSideBar.state_cache_key(:show).must_equal "post/cell/show/flat_side_bar/show/{}" }
+  end
+
+  describe "cache store" do
+    it do
+      Post::Cell::Show::SideBar.new(nil).()
+      Post::Cell::Show::FlatSideBar.new(nil).()
+
+      CacheStore::STORE.must_equal({
+        "post/cell/show/side_bar/show/"=>%{$side_bar
+},
+        "post/cell/show/flat_side_bar/show/"=>%{$flat_side_bar
+}
+      })
+    end
   end
 end


### PR DESCRIPTION
Fixes #13  

Note that this change doesn't remove `Cell or ::Cell` from cell's name, as it is being done in `controller_path`. I think `controller_path` is independent of cache key generation, though this is open for discussion.

```ruby
# Old behaviour

class Post::Cell::Show < Cell::ViewModel
  cache :show # cache key => "post/view/show/"
end
```

```ruby
# New behaviour

class Post::Cell::Show < Cell::ViewModel
  cache :show # cache key => "post/cell/show/show/"
end
```